### PR TITLE
Update: Edit next.config.js to enable AVIF support and still fallback…

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   images: {
+    formats: ['image/avif', 'image/webp'],
     remotePatterns: [
       {
         protocol: 'https',


### PR DESCRIPTION
- 画像フォーマットのAVIFのサポートを有効化するため、next.config.jsを編集しました。
- AVIFをサポートしていないブラウザの場合、WebPに自動的に切り替わるように設定してあります。